### PR TITLE
Mcp servers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -317,7 +317,7 @@ TTS_API_KEY=
 # RAG_OPENAI_BASEURL=
 # RAG_OPENAI_API_KEY=
 # RAG_USE_FULL_CONTEXT=
-# EMBEDDINGS_PROVIDER=openai
+EMBEDDINGS_PROVIDER=bedrock
 # EMBEDDINGS_MODEL=text-embedding-3-small
 
 #===================================================#

--- a/Dockerfile-debian-build
+++ b/Dockerfile-debian-build
@@ -1,0 +1,124 @@
+# Base image: Node.js 20 on Debian Bookworm
+# This image already includes Python, which we need for our application
+FROM node:20-bookworm
+
+# Install system dependencies:
+# - Python pip and venv for Python package management
+# - curl and git for downloading and version control
+# - Browsers and their dependencies for testing/rendering
+# - Additional system libraries required by the application
+RUN apt-get update && apt-get install -y \
+    python3-pip \
+    python3-venv \
+    curl \
+    git \
+    # Browser packages for Playwright/automated testing
+    chromium \
+    firefox-esr \
+    # X11 and graphics dependencies
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    # Audio and UI dependencies
+    libasound2 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libgtk-3-0 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libnss3 \
+    libxss1 \
+    # Font packages for proper text rendering
+    fonts-noto \
+    fonts-noto-color-emoji \
+    fonts-freefont-ttf \
+    # Media and content processing libraries
+    libwebp-dev \
+    libenchant-2-2 \
+    libvpx-dev \
+    libwoff-dev \
+    libopus0 \
+    libgudev-1.0-0 \
+    libsecret-1-0 \
+    libhyphen0 \
+    libgdk-pixbuf2.0-0 \
+    libegl1 \
+    libnotify4 \
+    libxslt1.1 \
+    libevent-2.1-7 \
+    libgles2 \
+    # Additional UI and multimedia dependencies
+    libxkbcommon0 \
+    libgstreamer-gl1.0-0 \
+    libgstreamer-plugins-bad1.0-0 \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    # Clean up package manager cache to reduce image size
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv (Python package installer, faster than pip)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh    
+
+# Set up working directory
+RUN mkdir -p /app
+WORKDIR /app
+
+# Copy application files
+COPY . .
+
+# Setup application:
+# - Create necessary files and directories
+# - Configure npm
+# - Install dependencies
+# - Build frontend
+# - Clean up unnecessary packages
+RUN \
+    # Create empty .env file if it doesn't exist
+    touch .env ; \
+    # Create directories for volume mounts
+    mkdir -p /app/client/public/images /app/api/logs ; \
+    # Configure npm retry settings for better reliability during installation
+    npm config set fetch-retry-maxtimeout 600000 ; \
+    npm config set fetch-retries 5 ; \
+    npm config set fetch-retry-mintimeout 15000 ; \
+    # Install dependencies
+    npm install --no-audit; \
+    # Build frontend with increased memory allocation
+    NODE_OPTIONS="--max-old-space-size=2048" npm run frontend; \
+    # Remove development dependencies
+    npm prune --production; \
+    # Clear npm cache
+    npm cache clean --force
+
+# Install Playwright (browser automation tool) and its dependencies
+RUN  npx -y playwright install-deps
+RUN  npx -y playwright install
+
+# Create directories for application data and logs
+RUN mkdir -p /app/client/public/images /app/api/logs
+
+# Configure container runtime
+EXPOSE 3080  # Expose API port
+# Environment variables for production setup
+ENV NODE_ENV=production \
+    PYTHONUNBUFFERED=1 \
+    HOST=0.0.0.0
+
+# Start the backend server
+CMD ["npm", "run", "backend"]
+
+# Below is an optional nginx configuration for serving the client
+# Commented out as it's not currently in use
+# FROM nginx:stable-alpine AS nginx-client
+# WORKDIR /usr/share/nginx/html
+# COPY --from=node /app/client/dist /usr/share/nginx/html
+# COPY client/nginx.conf /etc/nginx/conf.d/default.conf
+# ENTRYPOINT ["nginx", "-g", "daemon off;"]
+ 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - pgdata2:/var/lib/postgresql/data
   rag_api:
     container_name: rag_api
-    image: ghcr.io/danny-avila/librechat-rag-api-dev-lite:latest
+    image: ghcr.io/danny-avila/librechat-rag-api-dev:latest
     environment:
       - DB_HOST=vectordb
       - RAG_PORT=${RAG_PORT:-8000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     restart: always
     user: "${UID}:${GID}"
     volumes:
-      - ./data-node:/data/db
+      - mongodb_data:/data/db
     command: mongod --noauth
   meilisearch:
     container_name: chat-meilisearch
@@ -70,3 +70,4 @@ services:
 
 volumes:
   pgdata2:
+  mongodb_data:

--- a/mcp_servers.yaml
+++ b/mcp_servers.yaml
@@ -48,4 +48,17 @@ mcpServers:
       - mcp-timeserver
     env:
       PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin"
+
+  # MCP Server for AWS Knowledge Base Retrieval
+  aws-kb-retrieval:
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - "@modelcontextprotocol/server-aws-kb-retrieval"
+    env:
+      AWS_ACCESS_KEY_ID: "YOUR_ACCESS_KEY_HERE"
+      AWS_SECRET_ACCESS_KEY: "YOUR_SECRET_ACCESS_KEY_HERE"
+      AWS_REGION: "YOUR_AWS_REGION_HERE"
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   

--- a/mcp_servers.yaml
+++ b/mcp_servers.yaml
@@ -39,3 +39,13 @@ mcpServers:
       - "@modelcontextprotocol/server-puppeteer"
     env:
       PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+  # MCP-timeserver - Server for providing time-related functions and services
+  MCP-timeserver:
+    type: stdio
+    command: uvx
+    args:
+      - mcp-timeserver
+    env:
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin"
+  

--- a/mcp_servers.yaml
+++ b/mcp_servers.yaml
@@ -17,5 +17,15 @@ mcpServers:
       - -y
       - "@modelcontextprotocol/server-brave-search"
     env:
-      BRAVE_API_KEY: "<YOUR_BRAVE_API_KEY>"
+      BRAVE_API_KEY: "BSAbtJya-Rq9Y9EpZ2qROgVYMno4d6t"
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+  # MCP Server for Playwright
+  playwright:
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - "@executeautomation/playwright-mcp-server"
+    env:
       PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/mcp_servers.yaml
+++ b/mcp_servers.yaml
@@ -1,0 +1,8 @@
+version: 1.0.8
+ 
+cache: true
+
+endpoints:
+  agents:
+    # (optional) Maximum recursion depth for agents, defaults to 25
+    recursionLimit: 50

--- a/mcp_servers.yaml
+++ b/mcp_servers.yaml
@@ -6,3 +6,16 @@ endpoints:
   agents:
     # (optional) Maximum recursion depth for agents, defaults to 25
     recursionLimit: 50
+
+
+# MCP Servers Configuration
+mcpServers:
+  brave:
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - "@modelcontextprotocol/server-brave-search"
+    env:
+      BRAVE_API_KEY: "<YOUR_BRAVE_API_KEY>"
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/mcp_servers.yaml
+++ b/mcp_servers.yaml
@@ -29,3 +29,13 @@ mcpServers:
       - "@executeautomation/playwright-mcp-server"
     env:
       PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+  # MCP Server for Puppeteer
+  puppeteer:
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - "@modelcontextprotocol/server-puppeteer"
+    env:
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@playwright/test": "^1.50.1",
     "@types/react-virtualized": "^9.22.0",
     "cross-env": "^7.0.3",
+    "elliptic": "^6.6.1",
     "eslint": "^9.20.1",
     "eslint-config-prettier": "^10.0.1",
     "eslint-import-resolver-typescript": "^3.7.0",
@@ -110,8 +111,7 @@
     "prettier": "^3.5.0",
     "prettier-eslint": "^16.3.0",
     "prettier-plugin-tailwindcss": "^0.6.11",
-    "typescript-eslint": "^8.24.0",
-    "elliptic": "^6.6.1"
+    "typescript-eslint": "^8.24.0"
   },
   "overrides": {
     "axios": "1.8.2",
@@ -141,5 +141,10 @@
       "admin/",
       "packages/"
     ]
+  },
+  "dependencies": {
+    "@executeautomation/playwright-mcp-server": "^0.3.1",
+    "playwright": "^1.51.0",
+    "puppeteer": "^24.4.0"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -71,7 +71,9 @@
     "@modelcontextprotocol/sdk": "^1.6.1",
     "diff": "^7.0.0",
     "eventsource": "^3.0.2",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "playwright": "^1.51.0",
+    "puppeteer": "^24.4.0"
   },
   "peerDependencies": {
     "keyv": "^4.5.4"


### PR DESCRIPTION
# MCP Integration and Infrastructure Updates

This PR introduces several Multi-Cloud Provisioner (MCP) integrations and infrastructure improvements.

## Key Changes

### MCP Integrations
- Added Brave Search MCP integration
- Added Playwright MCP integration
- Added Puppeteer MCP integration
- Added TimeServer MCP integration
- Added AWS Knowledge Base MCP integration

### Infrastructure Updates
- Updated tool recursion limit to 50 for improved stability
- Updated docker-compose configuration to use volume instead of host path for MongoDB
- Added new Dockerfile for Debian build with Python-based MCP support
- Enabled RAG API using Bedrock
- Updated project dependencies

## Technical Details
- Cloned and integrated mcp-playwright repository
- Infrastructure changes focus on containerization improvements and better volume management
- Enhanced API capabilities with Bedrock integration for RAG (Retrieval-Augmented Generation)

## Testing
Please verify:
- All MCP integrations function as expected
- Docker builds complete successfully with the new Debian configuration
- MongoDB persistence works correctly with the volume-based setup
- RAG API endpoints are accessible and functional